### PR TITLE
ABM-340: Crash while using app

### DIFF
--- a/PocketSocket/PSWebSocketServer.m
+++ b/PocketSocket/PSWebSocketServer.m
@@ -695,9 +695,7 @@ void PSWebSocketServerAcceptCallback(CFSocketRef s, CFSocketCallBackType type, C
 #pragma mark - Dealloc
 
 - (void)dealloc {
-    [self executeWorkAndWait:^{
-        [self disconnect:YES];
-    }];
+	[self disconnect:YES];
 }
 
 @end


### PR DESCRIPTION
Remove dispatch_sync call on the same queue from dealloc in order to avoid deadlock.

[Similar issue](https://github.com/zwopple/PocketSocket/issues/55)